### PR TITLE
Support of API 3.6

### DIFF
--- a/tests/Concern/SetupIntegrationTest.php
+++ b/tests/Concern/SetupIntegrationTest.php
@@ -34,14 +34,14 @@ trait SetupIntegrationTest
     protected function getApiVersion()
     {
         $api_version = getenv('KSEARCH_VERSION'); 
-        return  $api_version ? $api_version : '3.5';
+        return  $api_version ? $api_version : '3.6';
     }
 
-    public function skipIfApiVersionNotEqual($version)
+    public function skipIfApiVersionNotEqualOrAbove($version)
     {
         $envVersion = $this->getApiVersion();
 
-        if($envVersion !== $version){
+        if(version_compare($envVersion, $version, '<')){
             $this->markTestSkipped(
                 "Test skipped as require api [$version]. Environment version [$envVersion]."
             );

--- a/tests/Integration/SearchDataTest.php
+++ b/tests/Integration/SearchDataTest.php
@@ -175,7 +175,7 @@ class SearchDataTest extends TestCase
 
     public function test_search_filter_for_geographic_bounding_box()
     {
-        $this->skipIfApiVersionNotEqual('3.5');
+        $this->skipIfApiVersionNotEqualOrAbove('3.5');
 
         $this->clearIndexedDocuments();
         $this->addGeographicTestDummyData();
@@ -210,7 +210,7 @@ class SearchDataTest extends TestCase
 
     public function test_search_for_data_with_geo_location()
     {
-        $this->skipIfApiVersionNotEqual('3.5');
+        $this->skipIfApiVersionNotEqualOrAbove('3.5');
 
         $this->clearIndexedDocuments();
         $this->addTestDummyData();

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     networks:
       - internal
   ksearch:
-    image: "docker.klink.asia/images/k-search:3.5.1-1"
+    image: "docker.klink.asia/images/k-search:3.6.0-1"
     environment:
       - SOLR_HOST=engine
       - SOLR_CORE=k-search


### PR DESCRIPTION
The changes here are related to the K-Search API 3.6 that will lift some `required` fields